### PR TITLE
Release version 0.0.0.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+# v0.0.0.0
+
+Initial release.


### PR DESCRIPTION
No need to bump the .cabal version, since that's already set.